### PR TITLE
Adjust survey display and consolidate all surveys

### DIFF
--- a/src/pages/survey/SurveyDashboardPage.jsx
+++ b/src/pages/survey/SurveyDashboardPage.jsx
@@ -327,7 +327,7 @@ const SurveyDashboardPage = () => {
                   </td>
                 </tr>
               ) : (
-                recentSurveys.map((survey, index) => (
+                recentSurveys.slice(0, 10).map((survey, index) => (
                   <tr
                     key={index}
                     onClick={() => openSurvey(survey)}


### PR DESCRIPTION
Limit the number of recent surveys displayed on the dashboard to 10.

---
<a href="https://cursor.com/background-agent?bcId=bc-03e951d9-52f1-439d-b2a0-0cf402684d01">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-03e951d9-52f1-439d-b2a0-0cf402684d01">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

